### PR TITLE
fix: enable lsp and move config out of autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,38 +54,8 @@ Or with custom configuration:
 {
   "tamerlang/gh-actions-lsp.nvim",
   opts = {
-    -- Add any custom options here
+      fallback_org = "random-org", -- Optional: specify a fallback organization if organization cannot be determined in repo
   },
-  ft = { "yaml" }, -- Only load for YAML files
-  event = "VeryLazy" -- Or load on specific events
+  event = "VeryLazy" 
 }
 ```
-
-### Manual Installation
-
-If you prefer manual installation, clone this repository to your Neovim configuration directory:
-
-```bash
-git clone https://github.com/tamerlang/gh-actions-lsp.nvim ~/.config/nvim/pack/plugins/start/gh-actions-lsp.nvim
-```
-
-Then add the plugin to your configuration:
-
-```lua
-require("gh-actions-lsp").setup({})
-```
-
-## Usage
-
-The plugin automatically detects GitHub workflow files (`.github/workflows/*.yml` and `.github/workflows/*.yaml`) and attaches the Language Server when you open them.
-
-## Configuration
-
-The plugin uses sensible defaults, but you can customize its behavior:
-
-```lua
-require("gh-actions-lsp").setup({
-  -- Configuration options will be documented here as they're added
-})
-```
-

--- a/lua/gh-actions-lsp/init.lua
+++ b/lua/gh-actions-lsp/init.lua
@@ -42,48 +42,44 @@ function M.setup(opts)
     },
   })
 
-  vim.api.nvim_create_autocmd("FileType", {
-    pattern = "yaml.github",
-    callback = function()
-      vim.lsp.config["gh_actions"] = {
-        cmd = { "gh-actions-language-server", "--stdio" },
-        filetypes = { "yaml.github" },
-        init_options = get_gh_actions_init_options(nil, nil, opts.fallback_org),
-        single_file_support = true,
-        -- `root_dir` ensures that the LSP does not attach to all yaml files
-        root_dir = function(bufnr, on_dir)
-          local parent = vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
-          if vim.endswith(parent, "/.github/workflows") then
-            on_dir(parent)
-          end
-        end,
-        handlers = {
-          ["actions/readFile"] = function(_, result)
-            if type(result.path) ~= "string" then
-              return nil, { code = -32602, message = "Invalid path parameter" }
-            end
-            local file_path = vim.uri_to_fname(result.path)
-            if vim.fn.filereadable(file_path) == 1 then
-              local f = assert(io.open(file_path, "r"))
-              local text = f:read("*a")
-              f:close()
-              return text, nil
-            else
-              return nil, { code = -32603, message = "File not found: " .. file_path }
-            end
-          end,
-        },
-
-        capabilities = {
-          workspace = {
-            didChangeWorkspaceFolders = {
-              dynamicRegistration = true,
-            },
-          },
-        },
-      }
+  vim.lsp.config["gh_actions"] = {
+    cmd = { "gh-actions-language-server", "--stdio" },
+    filetypes = { "yaml.github" },
+    init_options = get_gh_actions_init_options(nil, nil, opts.fallback_org),
+    single_file_support = true,
+    -- `root_dir` ensures that the LSP does not attach to all yaml files
+    root_dir = function(bufnr, on_dir)
+      local parent = vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
+      if vim.endswith(parent, "/.github/workflows") then
+        on_dir(parent)
+      end
     end,
-  })
+    handlers = {
+      ["actions/readFile"] = function(_, result)
+        if type(result.path) ~= "string" then
+          return nil, { code = -32602, message = "Invalid path parameter" }
+        end
+        local file_path = vim.uri_to_fname(result.path)
+        if vim.fn.filereadable(file_path) == 1 then
+          local f = assert(io.open(file_path, "r"))
+          local text = f:read("*a")
+          f:close()
+          return text, nil
+        else
+          return nil, { code = -32603, message = "File not found: " .. file_path }
+        end
+      end,
+    },
+    capabilities = {
+      workspace = {
+        didChangeWorkspaceFolders = {
+          dynamicRegistration = true,
+        },
+      },
+    },
+  }
+
+  vim.lsp.enable({ "gh_actions" })
 end
 
 return M


### PR DESCRIPTION
resolves #1 

- enable lsp directly in plugin 
- move config out of autocmd